### PR TITLE
Add clarifications for virtual env use and DAG details

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
   </a>
 </p>
 <h1 align="center">
-  Run Snowpark Queries in Airflow using the PythonVirtualEnvironment Operator
+  Run Snowpark Queries in Airflow using an External Virtual Environment
 </h1>
   <h3 align="center">
   In this tutorial, you'll learn how to use the ExternalPythonOperator to run a task that leverages the Snowpark API for data transformations. Snowpark allows you to run queries and transformations on your data using different programming languages, making it a flexible addition to traditional Snowflake operators.
 
-  
+
 
 </a>.
   </br></br>
@@ -23,7 +23,7 @@
 
   Snowpark requires Python 3.8, while the Astro Runtime uses Python 3.9. The ExternalPythonOperator can run your Snowpark query in a Python 3.8 virtual environment, allowing you to use a different Python version for your task than in the Airflow environment. You can use these same general steps for any use case for running a task in a reusable Python virtual environment.
 
-  To run this locally, make sure to enable buildkit for your local docker engine! 
+  To run this locally, make sure to enable buildkit for your local docker engine!
 </p>
 
 </br>

--- a/dags/external-python-pipeline.py
+++ b/dags/external-python-pipeline.py
@@ -1,6 +1,8 @@
 '''
-###Snowpark + PythonVirtualEnvironmentOperator DAG
-This DAG uses the PythonVirtualEnvironment Operator to run a Snowpark Query in Snowflake
+### Execute a Snowflake Query in a Python Virtual Environment with Snowpark
+
+This DAG showcases the @task.external_python TaskFlow decorator to run a Snowflake query via the Snowpark API
+in an external Python virtual environment.
 '''
 
 from __future__ import annotations
@@ -15,11 +17,11 @@ from airflow.decorators import task
 
 with DAG(
     "py_virtual_env",
-    schedule_interval=None,
+    schedule=None,
     start_date=pendulum.datetime(2022, 10, 10, tz="UTC"),
     catchup=False,
     tags=["pythonvirtualenv"],
-) as dag:
+):
 
     @task(task_id="print_the_context")
     def print_context(ds=None, **kwargs):
@@ -39,7 +41,7 @@ with DAG(
         conn_params = hook._get_conn_params()
         session = Session.builder.configs(conn_params).create()
         query = """
-            select avg(reps_upper), avg(reps_lower) 
+            select avg(reps_upper), avg(reps_lower)
             from dog_intelligence;
             """
         df = session.sql(query)


### PR DESCRIPTION
Small updates for Astronomer Registry publication:
- Correct the markdown title in the DAG docstring and update the copy
- Update the README to clarify the PythonVirtualEnvOperator is not used where applicable
- Trivial updates to DAG declaration for more recent Airflow version syntax